### PR TITLE
Fixing max_iters for all learners

### DIFF
--- a/src/main/java/de/bwaldvogel/liblinear/Linear.java
+++ b/src/main/java/de/bwaldvogel/liblinear/Linear.java
@@ -1798,7 +1798,7 @@ public class Linear {
                         C[i] = Cn;
                 }
                 fun_obj = new L2R_LrFunction(prob, C);
-                Tron tron_obj = new Tron(fun_obj, primal_solver_tol);
+                Tron tron_obj = new Tron(fun_obj, primal_solver_tol, param.max_iters);
                 tron_obj.tron(w);
                 break;
             }
@@ -1811,7 +1811,7 @@ public class Linear {
                         C[i] = Cn;
                 }
                 fun_obj = new L2R_L2_SvcFunction(prob, C);
-                Tron tron_obj = new Tron(fun_obj, primal_solver_tol);
+                Tron tron_obj = new Tron(fun_obj, primal_solver_tol, param.max_iters);
                 tron_obj.tron(w);
                 break;
             }
@@ -1840,7 +1840,7 @@ public class Linear {
                     C[i] = param.C;
 
                 fun_obj = new L2R_L2_SvrFunction(prob, C, param.p);
-                Tron tron_obj = new Tron(fun_obj, param.eps);
+                Tron tron_obj = new Tron(fun_obj, param.eps, param.max_iters);
                 tron_obj.tron(w);
                 break;
             }

--- a/src/main/java/de/bwaldvogel/liblinear/Linear.java
+++ b/src/main/java/de/bwaldvogel/liblinear/Linear.java
@@ -527,13 +527,12 @@ public class Linear {
      * See Algorithm 3 of Hsieh et al., ICML 2008
      *</pre>
      */
-    private static void solve_l2r_l1l2_svc(Problem prob, double[] w, double eps, double Cp, double Cn, SolverType solver_type) {
+    private static void solve_l2r_l1l2_svc(Problem prob, double[] w, double eps, double Cp, double Cn, SolverType solver_type, int max_iter) {
         int l = prob.l;
         int w_size = prob.n;
         int i, s, iter = 0;
         double C, d, G;
         double[] QD = new double[l];
-        int max_iter = 1000;
         int[] index = new int[l];
         double[] alpha = new double[l];
         byte[] y = new byte[l];
@@ -893,12 +892,11 @@ public class Linear {
      *
      * @since 1.7
      */
-    private static void solve_l2r_lr_dual(Problem prob, double w[], double eps, double Cp, double Cn) {
+    private static void solve_l2r_lr_dual(Problem prob, double w[], double eps, double Cp, double Cn, int max_iter) {
         int l = prob.l;
         int w_size = prob.n;
         int i, s, iter = 0;
         double xTx[] = new double[l];
-        int max_iter = 1000;
         int index[] = new int[l];
         double alpha[] = new double[2 * l]; // store alpha and C - alpha
         byte y[] = new byte[l];
@@ -1039,11 +1037,10 @@ public class Linear {
      *
      * @since 1.5
      */
-    private static void solve_l1r_l2_svc(Problem prob_col, double[] w, double eps, double Cp, double Cn) {
+    private static void solve_l1r_l2_svc(Problem prob_col, double[] w, double eps, double Cp, double Cn, int max_iter) {
         int l = prob_col.l;
         int w_size = prob_col.n;
         int j, s, iter = 0;
-        int max_iter = 1000;
         int active_size = w_size;
         int max_num_linesearch = 20;
 
@@ -1278,12 +1275,11 @@ public class Linear {
      *
      * @since 1.5
      */
-    private static void solve_l1r_lr(Problem prob_col, double[] w, double eps, double Cp, double Cn) {
+    private static void solve_l1r_lr(Problem prob_col, double[] w, double eps, double Cp, double Cn, int max_iter) {
         int l = prob_col.l;
         int w_size = prob_col.n;
         int j, s, newton_iter = 0, iter = 0;
         int max_newton_iter = 100;
-        int max_iter = 1000;
         int max_num_linesearch = 20;
         int active_size;
         int QP_active_size;
@@ -1816,23 +1812,23 @@ public class Linear {
                 break;
             }
             case L2R_L2LOSS_SVC_DUAL:
-                solve_l2r_l1l2_svc(prob, w, eps, Cp, Cn, SolverType.L2R_L2LOSS_SVC_DUAL);
+                solve_l2r_l1l2_svc(prob, w, eps, Cp, Cn, SolverType.L2R_L2LOSS_SVC_DUAL, param.max_iters);
                 break;
             case L2R_L1LOSS_SVC_DUAL:
-                solve_l2r_l1l2_svc(prob, w, eps, Cp, Cn, SolverType.L2R_L1LOSS_SVC_DUAL);
+                solve_l2r_l1l2_svc(prob, w, eps, Cp, Cn, SolverType.L2R_L1LOSS_SVC_DUAL, param.max_iters);
                 break;
             case L1R_L2LOSS_SVC: {
                 Problem prob_col = transpose(prob);
-                solve_l1r_l2_svc(prob_col, w, primal_solver_tol, Cp, Cn);
+                solve_l1r_l2_svc(prob_col, w, primal_solver_tol, Cp, Cn, param.max_iters);
                 break;
             }
             case L1R_LR: {
                 Problem prob_col = transpose(prob);
-                solve_l1r_lr(prob_col, w, primal_solver_tol, Cp, Cn);
+                solve_l1r_lr(prob_col, w, primal_solver_tol, Cp, Cn, param.max_iters);
                 break;
             }
             case L2R_LR_DUAL:
-                solve_l2r_lr_dual(prob, w, eps, Cp, Cn);
+                solve_l2r_lr_dual(prob, w, eps, Cp, Cn, param.max_iters);
                 break;
             case L2R_L2LOSS_SVR: {
                 double[] C = new double[prob.l];


### PR DESCRIPTION
Fixed Linear.train_one to receive the max_iter from Parameter object
Changes are listed below:

1. For solvers that where using Tron class (L2R_LR, L2R_L2LOSS_SVC,
L2R_L2LOSS_SVR):
the class already had a constructor that would receive the max_iter as
argument. But, it wasn't used. Therefore the learner would automatically
just use 1000. 

2. For rest of the solvers(L2R_LR_DUAL, L1R_LR, L1R_L2LOSS_SVC,
L2R_L1LOSS_SVC_DUAL, L2R_L2LOSS_SVC_DUAL):
the function changed to receive the max_iter as argument. All the
function where defining a constant at the begining of the function.

3. L2R_L2LOSS_SVR_DUAL and L2R_L1LOSS_SVR_DUAL were already handling it,
so no changes was applied to this solver type