### PR TITLE
Added reasonable error message to loadModel parsing

### DIFF
--- a/src/main/java/de/bwaldvogel/liblinear/Linear.java
+++ b/src/main/java/de/bwaldvogel/liblinear/Linear.java
@@ -293,16 +293,26 @@ public class Linear {
         for (int i = 0; i < w_size; i++) {
             for (int j = 0; j < nr_w; j++) {
                 int b = 0;
-                while (true) {
-                    int ch = reader.read();
-                    if (ch == -1) {
-                        throw new EOFException("unexpected EOF");
+                try {
+                    while (true) {
+                        int ch = reader.read();
+                        if (ch == -1) {
+                            throw new EOFException("unexpected EOF");
+                        }
+                        if (ch == ' ') {
+                            model.w[i * nr_w + j] = atof(new String(buffer, 0, b));
+                            break;
+                        } else {
+                            buffer[b++] = ch;
+                        }
                     }
-                    if (ch == ' ') {
-                        model.w[i * nr_w + j] = atof(new String(buffer, 0, b));
-                        break;
+                } catch (ArrayIndexOutOfBoundsException aioobex) {
+                    if (b > 127) {
+                        throw new RuntimeException("in model file, weight at index " + (i * nr_w + j) + ", with string content '" +
+                                                   new String(buffer, 0, 127) + "', is not terminated " +
+                                                   "with a whitespace character, or is longer than expected (128 characters max).");
                     } else {
-                        buffer[b++] = ch;
+                        throw aioobex;
                     }
                 }
             }


### PR DESCRIPTION
...when feature vector weights don't end with a whitespace character.

Spent a bit too much time this morning debugging this - would've been really helpful to me to just get a straightforward error message suggesting that my model was semantically incorrect from the point of view of the parser, and describing how and where.

The fix is basically to catch the ArrayIndexOutOfBoundsException, and if b > 127, then throw a different RuntimeException with a message actually spelling out what went wrong. Otherwise, just throw the original exception.